### PR TITLE
Remove the `Env` module from the public API and make linting function more library friendly

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -10,22 +10,14 @@ let lint (changed_pkgs, new_pkgs) local_repo_dir =
   | None -> `Error (true, "No opam repository directory specified.")
 
 let show_revdeps pkg local_repo_dir no_transitive_revdeps =
-  (* Create local opam root and switch *)
-  Env.create_local_switch_maybe local_repo_dir;
-
   (* Get revdeps for the package *)
-  let revdeps = Revdeps.list_revdeps pkg no_transitive_revdeps in
-
+  let revdeps = Revdeps.list_revdeps local_repo_dir pkg no_transitive_revdeps in
   Revdeps.Display.packages revdeps;
-
   ()
 
 let test_revdeps pkg local_repo_dir use_dune no_transitive_revdeps =
-  (* Create local opam root and switch *)
-  Env.create_local_switch_maybe local_repo_dir;
-
   (* Get revdeps for the package *)
-  let revdeps = Revdeps.list_revdeps pkg no_transitive_revdeps in
+  let revdeps = Revdeps.list_revdeps local_repo_dir pkg no_transitive_revdeps in
 
   (* Install and test the first reverse dependency *)
   let latest_versions = Revdeps.find_latest_versions revdeps in

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -6,14 +6,14 @@ let lint (changed_pkgs, new_pkgs) local_repo_dir =
   | Some d ->
       print_endline @@ Printf.sprintf "Linting opam-repository at %s ..." d;
       Lint.run_lint ~new_pkgs ~changed_pkgs d;
-      `Ok ()
-  | None -> `Error (true, "No opam repository directory specified.")
+      Ok ()
+  | None -> Error ("No opam repository directory specified.")
 
 let show_revdeps pkg local_repo_dir no_transitive_revdeps =
   (* Get revdeps for the package *)
   let revdeps = Revdeps.list_revdeps local_repo_dir pkg no_transitive_revdeps in
   Revdeps.Display.packages revdeps;
-  ()
+  Ok ()
 
 let test_revdeps pkg local_repo_dir use_dune no_transitive_revdeps =
   (* Get revdeps for the package *)
@@ -24,13 +24,10 @@ let test_revdeps pkg local_repo_dir use_dune no_transitive_revdeps =
 
   Revdeps.Display.packages latest_versions;
 
-  (match (use_dune, local_repo_dir) with
+  match (use_dune, local_repo_dir) with
   | true, Some d -> Test.test_packages_with_dune d pkg latest_versions
-  | true, None ->
-      OpamConsole.msg "Opam local repository path must be specified!\n"
-  | false, _ -> Test.test_packages_with_opam pkg latest_versions);
-
-  ()
+  | true, None -> Error "Opam local repository path must be specified!\n"
+  | false, _ -> Test.test_packages_with_opam pkg latest_versions
 
 let make_abs_path s =
   if Filename.is_relative s then Filename.concat (Sys.getcwd ()) s else s
@@ -109,7 +106,7 @@ let packages_term =
 
 let lint_cmd =
   let doc = "Lint the opam repository directory" in
-  let term = Term.(ret (const lint $ packages_term $ local_opam_repo_term)) in
+  let term = Term.(const lint $ packages_term $ local_opam_repo_term) in
   let info =
     Cmd.info "lint" ~doc ~sdocs:"COMMON OPTIONS" ~exits:Cmd.Exit.defaults
   in
@@ -139,11 +136,11 @@ let test_cmd =
   in
   Cmd.v info term
 
-let cmd =
+let cmd : (unit, string) result Cmd.t =
   let doc = "A tool to list revdeps and test the revdeps locally" in
   let exits = Cmd.Exit.defaults in
-  let term = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
+  (* let term = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in *)
   let info = Cmd.info "opam-ci-check" ~doc ~sdocs:"COMMON OPTIONS" ~exits in
-  Cmd.group ~default:term info [ lint_cmd; list_cmd; test_cmd ]
+  Cmd.group info [ lint_cmd; list_cmd; test_cmd ]
 
-let () = exit (Cmd.eval cmd)
+let () = exit (Cmd.eval_result cmd)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -5,9 +5,9 @@ let lint (changed_pkgs, new_pkgs) local_repo_dir =
   match local_repo_dir with
   | Some d ->
       print_endline @@ Printf.sprintf "Linting opam-repository at %s ..." d;
-      Lint.run_lint ~new_pkgs ~changed_pkgs d;
+      Lint.check ~new_pkgs ~changed_pkgs d;
       Ok ()
-  | None -> Error ("No opam repository directory specified.")
+  | None -> Error "No opam repository directory specified."
 
 let show_revdeps pkg local_repo_dir no_transitive_revdeps =
   (* Get revdeps for the package *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -155,8 +155,8 @@ let test_cmd =
 let cmd : Cmd.Exit.code Cmd.t =
   let doc = "A tool to list revdeps and test the revdeps locally" in
   let exits = Cmd.Exit.defaults in
-  (* let term = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in *)
+  let default = Term.(ret (const (fun _ -> `Help (`Pager, None)) $ const ())) in
   let info = Cmd.info "opam-ci-check" ~doc ~sdocs:"COMMON OPTIONS" ~exits in
-  Cmd.group info [ lint_cmd; list_cmd; test_cmd ]
+  Cmd.group ~default info [ lint_cmd; list_cmd; test_cmd ]
 
 let () = exit (Cmd.eval' cmd)

--- a/dune-project
+++ b/dune-project
@@ -24,6 +24,8 @@
    (>= 4.14.0))
   dune
   sexplib
+  (cmdliner
+   (>= 1.1.1))
   (opam-client
    (>= 2.2))
   (mula

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -525,7 +525,5 @@ let check ~new_pkgs ~changed_pkgs repo_dir =
     |> List.concat
   in
   match new_pkg_errors @ changed_errors with
-  | [] -> print_endline "No errors"
-  | errors ->
-      errors |> List.iter (fun e -> e |> msg_of_error |> print_endline);
-      exit 1
+  | [] -> None
+  | errors -> Some errors

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -515,7 +515,7 @@ let run_package_lint ~newly_published ~repo_dir pkg =
           Checks.run_checks ~repo_dir ~pkg ~packages ~newly_published opam
       | Error _ -> [ Checks.parse_error pkg ])
 
-let run_lint ~new_pkgs ~changed_pkgs repo_dir =
+let check ~new_pkgs ~changed_pkgs repo_dir =
   let changed_errors =
     List.map (run_package_lint ~newly_published:false ~repo_dir) changed_pkgs
     |> List.concat

--- a/lib/opam_ci_check.ml
+++ b/lib/opam_ci_check.ml
@@ -1,4 +1,3 @@
-module Env = Env
 module Revdeps = Revdeps
 module Test = Test
 module Lint = Lint

--- a/lib/revdeps.ml
+++ b/lib/revdeps.ml
@@ -54,7 +54,9 @@ let non_transitive_revdeps st package_set =
   OpamPackage.Set.filter packages_depending_on_target_packages
     all_known_packages
 
-let list_revdeps pkg no_transitive_revdeps =
+let list_revdeps local_repo_dir pkg no_transitive_revdeps =
+  (* Create local opam root and switch *)
+  Env.create_local_switch_maybe local_repo_dir;
   OpamConsole.msg "Listing revdeps for %s\n" pkg;
   let package = OpamPackage.of_string pkg in
   let package_set = OpamPackage.Set.singleton package in

--- a/lib/test.ml
+++ b/lib/test.ml
@@ -50,7 +50,7 @@ let test_packages_with_opam target_pkg revdeps_list =
 
       List.iter (test_package_with_opam target) revdeps_list
   | _ -> print_endline "Quitting!");
-  ()
+  Ok ()
 
 let test_packages_with_dune opam_repository target_pkg packages =
   let target = OpamPackage.of_string target_pkg in
@@ -70,4 +70,4 @@ let test_packages_with_dune opam_repository target_pkg packages =
     H.create_dummy_projects parent opam_repository target selected_packages
   in
   List.iter H.generate_lock_and_build dirs;
-  ()
+  Ok ()

--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "dune" {>= "3.15"}
   "sexplib"
+  "cmdliner" {>= "1.1.1"}
   "opam-client" {>= "2.2"}
   "mula" {>= "0.1.2"}
   "odoc" {with-doc}


### PR DESCRIPTION
This is preparatory work for #12. It makes a few changes that reduce the surface area of the library API, and make the entry point of the linting function more useful to other programs.

- afaict, there is no reason to expose the `Eval` module in the public interface of the library, so I've moved use of that into the linting module.
- I fiddled with the cmdliner usage a bit a avoid the discouraged `ret` API and to enable making error handling and reporting more streamlined.
- This make it natural to have the linting function return error data, rather than just call exit, which will allow other programs to use that function to inspect the errors it reports in the future.

