### PR TITLE
Check that default, example tags have been removed

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -268,6 +268,21 @@ module Checks = struct
         else Some (pkg, MaintainerEmailMissing m))
       maintainers
 
+  let check_tags ~pkg opam =
+    (* Check if any of the default tags are present *)
+    let tags = OpamFile.OPAM.tags opam in
+    let default_tags =
+      [ "add topics"; "topics"; "to describe"; "your"; "project" ]
+    in
+    let default_tags_present =
+      List.filter_map
+        (fun tag -> if List.mem tag tags then Some tag else None)
+        default_tags
+    in
+    match default_tags_present with
+    | [] -> []
+    | _ -> [ (pkg, DefaultTagsPresent default_tags_present) ]
+
   let opam_lint ~pkg opam =
     OpamFileTools.lint ~check_upstream:true opam
     |> List.map (fun x -> (pkg, OpamLint x))
@@ -352,6 +367,7 @@ module Checks = struct
         check_package_dir ~repo_dir;
         opam_lint;
         check_maintainer_email;
+        check_tags;
         check_no_pin_depends;
         check_no_extra_files;
         Prefix.check_prefix_conflict_class_mismatch;

--- a/lib/lint_error.ml
+++ b/lib/lint_error.ml
@@ -30,6 +30,7 @@ type error =
   | RestrictedPrefix of string
   | PrefixConflictClassMismatch of prefix_conflict_class_mismatch
   | ParseError
+  | DefaultTagsPresent of string list
 
 (**/**)
 
@@ -145,3 +146,8 @@ let msg_of_error (package, (err : error)) =
         pkg maintainer
   | ParseError ->
       Printf.sprintf "Error in %s: Failed to parse the opam file" pkg
+  | DefaultTagsPresent tags ->
+      Printf.sprintf
+        "Warning in %s: The package has not replaced the following default, \
+         example tags: %s"
+        pkg (String.concat ", " tags)

--- a/test/lint.t
+++ b/test/lint.t
@@ -44,6 +44,7 @@ Setup repo for incorrect b package tests
 Test the following:
 - [b.0.0.1] is missing the [author] field
 - [b.0.0.1] is missing the maintainer's email in the [maintainer] field
+- [b.0.0.1] has default, example tags
 - [b.0.0.2] has an extra unknown field
 - [b.0.0.3] has a pin-depends present, and a conflict class without the required prefix; use of extra-files and a weak checksum algorithm
 - [system-b.0.0.1] is using a restricted prefix in its name
@@ -56,6 +57,7 @@ Test the following:
   Linting opam-repository at $TESTCASE_ROOT/. ...
   Error in b.0.0.1:            warning 25: Missing field 'authors'
   Error in b.0.0.1: Maintainer email missing. Please add a maintainer email to the opam file. Maintainer: Jane
+  Warning in b.0.0.1: The package has not replaced the following default, example tags: topics, project
   [1]
   $ opam-ci-check lint -r . -c b.0.0.2
   Linting opam-repository at $TESTCASE_ROOT/. ...

--- a/test/patches/b-incorrect-opam.patch
+++ b/test/patches/b-incorrect-opam.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000..3697498
 --- /dev/null
 +++ b/packages/b/b.0.0.1/opam
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,14 @@
 +opam-version: "2.0"
 +synopsis: "Synopsis"
 +description: "Description"
@@ -13,6 +13,7 @@ index 0000000..3697498
 +bug-reports: "https://github.com/ocurrent/opam-repo-ci/issues"
 +dev-repo: "git+https://github.com/ocurrent/opam-repo-ci.git"
 +doc: "https://ocurrent.github.io/ocurrent/"
++tags: ["topics" "sample" "project"]
 +build: []
 +depends: [
 +  "a-1" {>= "0.0.1"}


### PR DESCRIPTION
Lot of repositories in the opam repository have "topics" as their first tag, possibly due to an oversight from the maintainers. This commit adds an explicit check to warn against that.

Closes #26.