### PR TITLE
Use random integers suffix for temporary file names

### DIFF
--- a/lib/dir_helpers.ml
+++ b/lib/dir_helpers.ml
@@ -2,12 +2,16 @@
  * Copyright (c) 2024 Puneeth Chaganti <punchagan@muse-amuse.in>, Shon Feder <shon.feder@gmail.com>, Tarides <contact@tarides.com>
  *)
 
+(*Generate random temporary file names. **)
+let temp_file_name dir prefix suffix =
+  let prng = Random.State.make_self_init () in
+  let random_suffix = string_of_int (Random.State.int prng 0x10000000) in
+  Filename.concat dir (prefix ^ random_suffix ^ suffix)
+
+(*Create a temporary directory with the given prefix. **)
 let create_temp_dir prefix =
   let base_temp_dir = Filename.get_temp_dir_name () in
-  let unique_temp_dir =
-    Filename.concat base_temp_dir
-      (prefix ^ (Unix.time () |> int_of_float |> string_of_int))
-  in
+  let unique_temp_dir = temp_file_name base_temp_dir prefix "" in
   Unix.mkdir unique_temp_dir 0o700;
   unique_temp_dir
 


### PR DESCRIPTION
Previously, we used the timestamp to create temporary file names and this could lead to non-unique file names. This commit improves the generation of temporary directory names and reduces the chances of conflicting directory names.