### PR TITLE
Fix removing directories with broken symlinks

### DIFF
--- a/lib/dir_helpers.ml
+++ b/lib/dir_helpers.ml
@@ -17,8 +17,11 @@ let remove_dir dir =
     Array.iter
       (fun entry ->
         let entry = Filename.concat dir entry in
-        if Sys.is_directory entry then remove_dir_rec entry
-        else Sys.remove entry)
+        let entry_is_directory =
+          (* Sys.is_directory raises a Sys_error for broken symlinks *)
+          try Sys.is_directory entry with Sys_error _ -> false
+        in
+        if entry_is_directory then remove_dir_rec entry else Sys.remove entry)
       entries;
     Sys.rmdir dir
   in

--- a/test/lint.t
+++ b/test/lint.t
@@ -35,7 +35,8 @@ Setup repo for incorrect b package tests
   Created tarball b.0.0.4.tgz
   Updated checksum for b.0.0.4.tgz in b.0.0.4's opam file
   $ echo "(lang dune 3.16)" > dune-project
-  $ sh "scripts/setup_sources.sh" b 0.0.5 dune-project
+  $ ln -s /tmp/non-existant-link random-link
+  $ sh "scripts/setup_sources.sh" b 0.0.5 dune-project random-link
   Created tarball b.0.0.5.tgz
   Updated checksum for b.0.0.5.tgz in b.0.0.5's opam file
   $ git commit -qm b-incorrect-opam


### PR DESCRIPTION
Sys.is_directory raises a Sys_error for broken symlinks, which causes the remove_dir function to fail. This commit fixes it by catching it and using Sys.remove in those cases.

Addresses failures like [this](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/1379fba4515ae339d82941a8342de4c37b12040b/variant/(lint)) and [this](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/41de505ec8ff3637ab3cb06a41ccbc29683f566c/variant/(lint))