### PR TITLE
Set lower bound on opam 2.3.0

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -5,8 +5,11 @@
 open Cmdliner
 open Opam_ci_check
 
+(* This is Cmdliner.Term.map, which is not available in Cmdliner 1.1.1 *)
+let map_term f x = Term.app (Term.const f) x
+
 let to_exit_code : (unit, string) result Term.t -> Cmd.Exit.code Term.t =
-  Term.map @@ function
+  map_term @@ function
   | Ok () -> 0
   | Error msg ->
       Printf.eprintf "%s%!" msg;

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
   (cmdliner
    (>= 1.1.1))
   (opam-client
-   (>= 2.2))
+   (>= 2.3.0~alpha1))
   (mula
    (>= 0.1.2)))
  (tags

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -399,7 +399,7 @@ let run_package_lint ~newly_published ~repo_dir pkg =
   In_channel.with_open_text opam_path (fun ic ->
       let opam =
         try Ok (OpamFile.OPAM.read_from_channel ic)
-        with OpamPp.Bad_format e | OpamPp.Bad_version e -> Error e
+        with OpamPp.Bad_format e | OpamPp.Bad_version (e, _) -> Error e
       in
       match opam with
       | Ok opam ->

--- a/opam-ci-check.opam
+++ b/opam-ci-check.opam
@@ -22,7 +22,7 @@ depends: [
   "dune" {>= "3.15"}
   "sexplib"
   "cmdliner" {>= "1.1.1"}
-  "opam-client" {>= "2.2"}
+  "opam-client" {>= "2.3.0~alpha1"}
   "mula" {>= "0.1.2"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Closes #42

The approach taken here is to adopt the latest version of opam and make the
change needed to support it.

https://github.com/ocurrent/opam-repo-ci/pull/366 shows that we can install this update into opam-repo-ci (with a minor change so that it is also able to support opam-client.2.3).